### PR TITLE
constant strings to s-ops (the wrap function)

### DIFF
--- a/raspy/rasp.py
+++ b/raspy/rasp.py
@@ -191,7 +191,7 @@ def wrap(x: SOpLike) -> SOp:
     if (
         isinstance(x, float)
         or isinstance(x, int)
-        or (isinstance(x, str) and len(x) == 1)
+        or isinstance(x, str)
     ):
         return repeat(x)  # type: ignore
     return raw(x)  # type: ignore


### PR DESCRIPTION
when converting a constant to an s-op, handle conversion of strings with multiple characters as well, e.g. so "aa" is actually interpreted as ["aa",...,"aa"] repeated as many times as the input length. things like tokens=="aa" act weird without this. this does not affect handling of string inputs in general, e.g.  length("hi") is still [2.0,2.0]