### PR TITLE
Make `chalk-diagrams` an optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "raspy"
+version = "0.1.0"
+description = "A reimplementation for RASP completely in Python as an embedded DSL"
+readme = "README.md"
+requires-python = ">=3.11"
+
+[project.optional-dependencies]
+draw = ["chalk-diagrams"]
+
+[dependency-groups]
+dev = ["pytest>=8.4.2"]
+
+[tool.uv.sources]
+chalk-diagrams = { git = "https://github.com/chalk-diagrams/chalk/" }

--- a/raspy/__init__.py
+++ b/raspy/__init__.py
@@ -10,4 +10,10 @@ from .rasp import (  # noqa: F401,F403
     tokens,
     where,
 )
-from .visualize import *
+
+try:
+    from .visualize import *
+except ImportError:
+    print(
+        "warning: Visualizations are not available. Install `chalk-diagrams` for visualization features."
+    )

--- a/raspy/visualize.py
+++ b/raspy/visualize.py
@@ -49,7 +49,6 @@ def draw_sel(self):
 
 
 def draw(bself):
-
     self = bself.sel
     d = draw_sel(self)
 
@@ -152,6 +151,7 @@ def qdraw(self):
         | vcat([word(w, green) for w in self.sop(EXAMPLE).val])
     )
 
+
 def kdraw(self):
     return draw_svg(
         word("key", blue).with_envelope(rectangle(4, 1))
@@ -159,9 +159,8 @@ def kdraw(self):
         | hcat([word(w, orange) for w in self.sop(EXAMPLE).val])
     )
 
+
 Key._repr_svg_ = kdraw
-
-
 
 
 Query._repr_svg_ = qdraw


### PR DESCRIPTION
The implementation of RASP in python as an embedded DSL is valuable in itself, and the visualizations module should be an extra.
Adds `.toml`, optional and dev dependency groups.